### PR TITLE
Retrieve commits history data from GitHub API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "octokit": "^4.0.2"
       },
       "devDependencies": {
         "@babel/core": "^7.24.6",
@@ -2469,11 +2470,53 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@octokit/app": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-15.0.1.tgz",
+      "integrity": "sha512-nwSjC349E6/wruMCo944y1dBC7uKzUYrBMoC4Qx/xfLLBmD+R66oMKB1jXS2HYRF9Hqh/Alq3UNRggVWZxjvUg==",
+      "dependencies": {
+        "@octokit/auth-app": "^7.0.0",
+        "@octokit/auth-unauthenticated": "^6.0.0",
+        "@octokit/core": "^6.1.2",
+        "@octokit/oauth-app": "^7.0.0",
+        "@octokit/plugin-paginate-rest": "^11.0.0",
+        "@octokit/types": "^13.0.0",
+        "@octokit/webhooks": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-7.1.0.tgz",
+      "integrity": "sha512-cazGaJPSgeZ8NkVYeM/C5l/6IQ5vZnsI8p1aMucadCkt/bndI+q+VqwrlnWbASRmenjOkf1t1RpCKrif53U8gw==",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^8.1.0",
+        "@octokit/auth-oauth-user": "^5.1.0",
+        "@octokit/request": "^9.1.1",
+        "@octokit/request-error": "^6.1.1",
+        "@octokit/types": "^13.4.1",
+        "lru-cache": "^10.0.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-app/node_modules/lru-cache": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/@octokit/auth-oauth-app": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-8.1.1.tgz",
       "integrity": "sha512-5UtmxXAvU2wfcHIPPDWzVSAWXVJzG3NWsxb7zCFplCWEmMCArSZV0UQu5jw5goLQXbFyOr5onzEH37UJB3zQQg==",
-      "dev": true,
       "dependencies": {
         "@octokit/auth-oauth-device": "^7.0.0",
         "@octokit/auth-oauth-user": "^5.0.1",
@@ -2489,7 +2532,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-7.1.1.tgz",
       "integrity": "sha512-HWl8lYueHonuyjrKKIup/1tiy0xcmQCdq5ikvMO1YwkNNkxb6DXfrPjrMYItNLyCP/o2H87WuijuE+SlBTT8eg==",
-      "dev": true,
       "dependencies": {
         "@octokit/oauth-methods": "^5.0.0",
         "@octokit/request": "^9.0.0",
@@ -2504,7 +2546,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-5.1.1.tgz",
       "integrity": "sha512-rRkMz0ErOppdvEfnemHJXgZ9vTPhBuC6yASeFaB7I2yLMd7QpjfrL1mnvRPlyKo+M6eeLxrKanXJ9Qte29SRsw==",
-      "dev": true,
       "dependencies": {
         "@octokit/auth-oauth-device": "^7.0.1",
         "@octokit/oauth-methods": "^5.0.0",
@@ -2520,7 +2561,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
       "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
-      "dev": true,
       "engines": {
         "node": ">= 18"
       }
@@ -2529,7 +2569,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-6.1.0.tgz",
       "integrity": "sha512-zPSmfrUAcspZH/lOFQnVnvjQZsIvmfApQH6GzJrkIunDooU1Su2qt2FfMTSVPRp7WLTQyC20Kd55lF+mIYaohQ==",
-      "dev": true,
       "dependencies": {
         "@octokit/request-error": "^6.0.1",
         "@octokit/types": "^13.0.0"
@@ -2542,7 +2581,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
       "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
-      "dev": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.0.0",
@@ -2560,7 +2598,6 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
       "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
-      "dev": true,
       "dependencies": {
         "@octokit/types": "^13.0.0",
         "universal-user-agent": "^7.0.2"
@@ -2573,7 +2610,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
       "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
-      "dev": true,
       "dependencies": {
         "@octokit/request": "^9.0.0",
         "@octokit/types": "^13.0.0",
@@ -2587,7 +2623,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-7.1.2.tgz",
       "integrity": "sha512-4ntCOZIiTozKwuYQroX/ZD722tzMH8Eicv/cgDM/3F3lyrlwENHDv4flTCBpSJbfK546B2SrkKMWB+/HbS84zQ==",
-      "dev": true,
       "dependencies": {
         "@octokit/auth-oauth-app": "^8.0.0",
         "@octokit/auth-oauth-user": "^5.0.1",
@@ -2606,7 +2641,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-7.1.1.tgz",
       "integrity": "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA==",
-      "dev": true,
       "engines": {
         "node": ">= 18"
       }
@@ -2615,7 +2649,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-5.1.2.tgz",
       "integrity": "sha512-C5lglRD+sBlbrhCUTxgJAFjWgJlmTx5bQ7Ch0+2uqRjYv7Cfb5xpX4WuSC9UgQna3sqRGBL9EImX9PvTpMaQ7g==",
-      "dev": true,
       "dependencies": {
         "@octokit/oauth-authorization-url": "^7.0.0",
         "@octokit/request": "^9.1.0",
@@ -2629,14 +2662,87 @@
     "node_modules/@octokit/openapi-types": {
       "version": "22.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-      "dev": true
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
+    },
+    "node_modules/@octokit/openapi-webhooks-types": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-8.2.1.tgz",
+      "integrity": "sha512-msAU1oTSm0ZmvAE0xDemuF4tVs5i0xNnNGtNmr4EuATi+1Rn8cZDetj6NXioSf5LwnxEc209COa/WOSbjuhLUA=="
+    },
+    "node_modules/@octokit/plugin-paginate-graphql": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-5.2.2.tgz",
+      "integrity": "sha512-7znSVvlNAOJisCqAnjN1FtEziweOHSjPGAuc5W58NeGNAr/ZB57yCsjQbXDlWsVryA7hHQaEQPcBbJYFawlkyg==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.0.tgz",
+      "integrity": "sha512-n4znWfRinnUQF6TPyxs7EctSAA3yVSP4qlJP2YgI3g9d4Ae2n5F3XDOjbUluKRxPU3rfsgpOboI4O4VtPc6Ilg==",
+      "dependencies": {
+        "@octokit/types": "^13.5.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.1.tgz",
+      "integrity": "sha512-YMWBw6Exh1ZBs5cCE0AnzYxSQDIJS00VlBqISTgNYmu5MBdeM07K/MAJjy/VkNaH5jpJmD/5HFUvIZ+LDB5jSQ==",
+      "dependencies": {
+        "@octokit/types": "^13.5.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.1.tgz",
+      "integrity": "sha512-G9Ue+x2odcb8E1XIPhaFBnTTIrrUDfXN05iFXiqhR+SeeeDMMILcAnysOsxUpEWcQp2e5Ft397FCXTcPkiPkLw==",
+      "dependencies": {
+        "@octokit/request-error": "^6.0.0",
+        "@octokit/types": "^13.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.3.0.tgz",
+      "integrity": "sha512-B5YTToSRTzNSeEyssnrT7WwGhpIdbpV9NKIs3KyTWHX6PhpYn7gqF/+lL3BvsASBM3Sg5BAUYk7KZx5p/Ec77w==",
+      "dependencies": {
+        "@octokit/types": "^13.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^6.0.0"
+      }
     },
     "node_modules/@octokit/request": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
       "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
-      "dev": true,
       "dependencies": {
         "@octokit/endpoint": "^10.0.0",
         "@octokit/request-error": "^6.0.1",
@@ -2651,7 +2757,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
       "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
-      "dev": true,
       "dependencies": {
         "@octokit/types": "^13.0.0"
       },
@@ -2663,9 +2768,30 @@
       "version": "13.5.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
       "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-      "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^22.2.0"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "13.2.7",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-13.2.7.tgz",
+      "integrity": "sha512-sPHCyi9uZuCs1gg0yF53FFocM+GsiiBEhQQV/itGzzQ8gjyv2GMJ1YvgdDY4lC0ePZeiV3juEw4GbS6w1VHhRw==",
+      "dependencies": {
+        "@octokit/openapi-webhooks-types": "8.2.1",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/webhooks-methods": "^5.0.0",
+        "aggregate-error": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-5.1.0.tgz",
+      "integrity": "sha512-yFZa3UH11VIxYnnoOYCVoJ3q4ChuSOk2IVBBQ0O3xtKX4x9bmKb/1t+Mxixv2iUhzMdOl1qeWJqEhouXXzB3rQ==",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2774,8 +2900,7 @@
     "node_modules/@types/aws-lambda": {
       "version": "8.10.138",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.138.tgz",
-      "integrity": "sha512-71EHMl70TPWIAsFuHd85NHq6S6T2OOjiisPTrH7RgcjzpJpPh4RQJv7PvVvIxc6PIp8CLV7F9B+TdjcAES5vcA==",
-      "dev": true
+      "integrity": "sha512-71EHMl70TPWIAsFuHd85NHq6S6T2OOjiisPTrH7RgcjzpJpPh4RQJv7PvVvIxc6PIp8CLV7F9B+TdjcAES5vcA=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -3336,6 +3461,21 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/aggregate-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+      "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+      "dependencies": {
+        "clean-stack": "^5.2.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3595,8 +3735,7 @@
     "node_modules/before-after-hook": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-      "dev": true
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -3661,6 +3800,11 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3895,6 +4039,31 @@
       },
       "engines": {
         "node": ">= 10.0"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+      "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clean-stack/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -6403,6 +6572,17 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -7443,6 +7623,26 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
+    },
+    "node_modules/octokit": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-4.0.2.tgz",
+      "integrity": "sha512-wbqF4uc1YbcldtiBFfkSnquHtECEIpYD78YUXI6ri1Im5OO2NLo6ZVpRdbJpdnpZ05zMrVPssNiEo6JQtea+Qg==",
+      "dependencies": {
+        "@octokit/app": "^15.0.0",
+        "@octokit/core": "^6.0.0",
+        "@octokit/oauth-app": "^7.0.0",
+        "@octokit/plugin-paginate-graphql": "^5.0.0",
+        "@octokit/plugin-paginate-rest": "^11.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^13.0.0",
+        "@octokit/plugin-retry": "^7.0.0",
+        "@octokit/plugin-throttling": "^9.0.0",
+        "@octokit/request-error": "^6.0.0",
+        "@octokit/types": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -10456,11 +10656,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.0.tgz",
+      "integrity": "sha512-G5o6f95b5BggDGuUfKDApKaCgNYy2x7OdHY0zSMF081O0EJobw+1130VONhrA7ezGSV2FNOGyM+KQpQZAr9bIQ=="
+    },
     "node_modules/universal-user-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-      "dev": true
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "webpack-dev-server": "^5.0.4"
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "octokit": "^4.0.2"
   }
 }

--- a/server/controllers/githubController.js
+++ b/server/controllers/githubController.js
@@ -1,65 +1,125 @@
 import { Octokit } from 'octokit';
 
+// helper function to create fileController error objects
+// return value will be the object we pass into next, invoking global error handler
+const createErr = (errInfo) => {
+  const {method, type, err} = errInfo;
+  return {
+    log: `githubController.${method} ${type}: ERROR: ${typeof err === 'object' ? JSON.stringify(err) : err}`,
+    message: {err: `Error occurred in githubController.${method}. Check server logs for more details.`}
+  }
+}
+
 const githubController = {};
 
 // create an instance of octokit (octokit is used to interact with the GitHub REST API in JS scripts)
 githubController.connectOctokit = (req, res, next) => {
-    // TO-DO: error handling if accessToken does not exist
-    const octokit = new Octokit({
-        auth: req.session.accessToken
-    });
-    res.locals.octokit = octokit;
-    next();
+  // check for missing data
+  // console.log('CONNECT OCTOKIT: ACCESS TOKEN:   ', req.session.accessToken);
+  // if (!req.session.accessToken) return next(createErr({
+  //   method: 'connectOctokit',
+  //   type: 'receiving accessToken data',
+  //   err: 'Invalid data received'
+  // }));
+
+  const octokit = new Octokit({
+    auth: req.session.accessToken
+  });
+  res.locals.octokit = octokit;
+  next();
 };
 
 // gets the list of all commits for a particular repo for a particular author
 githubController.getCommits = async (req, res, next) => {
-    const { owner, repoName } = req.body;
-    // TO-DO: error handling if owner/repoName does not exist
-    // TO-DO: error handling if bad response from github
+  const { owner, repoName } = req.body;
 
-    const getCommitCode = async (owner, repoName, commitSha) => {
-        const gitCommitDiffs = await res.locals.octokit.request(`GET /repos/${owner}/${repoName}/commits/${commitSha}`, {
-            owner: 'OWNER',
-            repo: 'REPO',
-            ref: 'REF',
-            headers: {
-                "content-type": 'application/vnd.github.diff',
-                "Accept": 'application/vnd.github+json' 
-            }
-        });
+  // check for missing data
+  if (!owner || !repoName) return next(createErr({
+    method: 'getCommits',
+    type: 'receiving owner and repoName data',
+    err: 'Invalid data received'
+  }));
 
-        return gitCommitDiffs.data.files.map(file => ({
-            filename: file.filename,
-            patch: file.patch
-        }));
-    };
-
-    const result = [];
-
-    const gitCommits = await res.locals.octokit.request(`GET /repos/${owner}/${repoName}/commits`, {
+  // helper function to retrieve code details for a specified commit
+  const getCommitCode = async (owner, repoName, commitSha) => {
+    try {
+      const gitCommitDiffs = await res.locals.octokit.request(`GET /repos/${owner}/${repoName}/commits/${commitSha}`, {
         owner: owner,
         repo: repoName,
-        // without 'author' parameter this request returns all commits for this repo
-        author: owner,
-        headers: { "Accept": 'application/vnd.github+json' }
+        ref: commitSha,
+        headers: {
+          "content-type": 'application/vnd.github.diff',
+          "Accept": 'application/vnd.github+json' 
+        }
+      });
+      return gitCommitDiffs.data.files.map(file => ({
+        filename: file.filename,
+        patch: file.patch
+      }));
+    } catch (err) {
+      return next(createErr({
+        method: 'getCommits',
+        type: 'requesting commit diffs data to GitHub API',
+        err
+      }));
+    };
+  };
+
+  const result = [];
+
+  // gets the list of all commits from GitHub, this is essentially metadata about commits and doesn't include code details
+  try {
+    const gitCommits = await res.locals.octokit.request(`GET /repos/${owner}/${repoName}/commits`, {
+      owner: owner,
+      repo: repoName,
+      // without 'author' parameter this request returns all commits for this repo
+      author: owner,
+      headers: { "Accept": 'application/vnd.github+json' }
     });
+
     // remove all commit messages starting from "Merge", as these are automatic merge commits
     const validCommits = gitCommits.data.filter(cmt => !cmt.commit.message.includes("Merge", 0));
-
-    for (let cmt of validCommits) {
-        const files = await getCommitCode(owner, repoName, cmt.sha);
-        result.push({
+  
+    const commitPromises = validCommits.map(cmt => {
+      // Step 1. getCommitCode is an async func, so it returns a Promise #1
+      // Step 4. eventually we return Promise #2 to the mapped array 
+      return getCommitCode(owner, repoName, cmt.sha)
+        // Step 2. the Promise #1 returned from getCommitCode resolves with an array of file objects
+        .then(files => {
+          // Step 3. .then returns another Promise #2 which - when resolved - returns a modified object containing all information about the requested commit
+          return {
             author: owner,
             date: cmt.commit.author.date,
             message: cmt.commit.message,
             commitSha: cmt.sha,
             files
+          }
+        })
+        // not using global error handling here. Even if 1 commit request errors out, it returns a valid object which will be wrapped in Promise. Hence, Promise.all never resolved with reject, if requests for commit details partially fail.
+        .catch(err => {
+          console.error(`Failed to get commit code for commit ${cmt.sha}: ${err}`);
+          return {
+            author: owner,
+            date: cmt.commit.author.date,
+            message: cmt.commit.message,
+            commitSha: cmt.sha,
+            files: [],
+            error: 'Failed to retrieve commit details'
+          }
         });
-    }
-    res.locals.commits = result;
+    });
 
+    // Promise.all allows to process async requests for commit details in parallel, which helps to reduce time of processing for a large number of commits
+    const commits = await Promise.all(commitPromises);
+    res.locals.commits = commits;
     next();
+  } catch (err) {
+      return next(createErr({
+        method: 'getCommits',
+        type: 'requesting commits data to GitHub API',
+        err
+      }));
+  };
 };
 
 export { githubController };

--- a/server/controllers/githubController.js
+++ b/server/controllers/githubController.js
@@ -1,0 +1,65 @@
+import { Octokit } from 'octokit';
+
+const githubController = {};
+
+// create an instance of octokit (octokit is used to interact with the GitHub REST API in JS scripts)
+githubController.connectOctokit = (req, res, next) => {
+    // TO-DO: error handling if accessToken does not exist
+    const octokit = new Octokit({
+        auth: req.session.accessToken
+    });
+    res.locals.octokit = octokit;
+    next();
+};
+
+// gets the list of all commits for a particular repo for a particular author
+githubController.getCommits = async (req, res, next) => {
+    const { owner, repoName } = req.body;
+    // TO-DO: error handling if owner/repoName does not exist
+    // TO-DO: error handling if bad response from github
+
+    const getCommitCode = async (owner, repoName, commitSha) => {
+        const gitCommitDiffs = await res.locals.octokit.request(`GET /repos/${owner}/${repoName}/commits/${commitSha}`, {
+            owner: 'OWNER',
+            repo: 'REPO',
+            ref: 'REF',
+            headers: {
+                "content-type": 'application/vnd.github.diff',
+                "Accept": 'application/vnd.github+json' 
+            }
+        });
+
+        return gitCommitDiffs.data.files.map(file => ({
+            filename: file.filename,
+            patch: file.patch
+        }));
+    };
+
+    const result = [];
+
+    const gitCommits = await res.locals.octokit.request(`GET /repos/${owner}/${repoName}/commits`, {
+        owner: owner,
+        repo: repoName,
+        // without 'author' parameter this request returns all commits for this repo
+        author: owner,
+        headers: { "Accept": 'application/vnd.github+json' }
+    });
+    // remove all commit messages starting from "Merge", as these are automatic merge commits
+    const validCommits = gitCommits.data.filter(cmt => !cmt.commit.message.includes("Merge", 0));
+
+    for (let cmt of validCommits) {
+        const files = await getCommitCode(owner, repoName, cmt.sha);
+        result.push({
+            author: owner,
+            date: cmt.commit.author.date,
+            message: cmt.commit.message,
+            commitSha: cmt.sha,
+            files
+        });
+    }
+    res.locals.commits = result;
+
+    next();
+};
+
+export { githubController };

--- a/server/routes/githubRouter.js
+++ b/server/routes/githubRouter.js
@@ -1,10 +1,14 @@
 import express from 'express';
 import { githubController } from '../controllers/githubController.js';
+import { authController } from '../controllers/authController.js';
 
 const githubRouter = express.Router();
 
-githubRouter.post('/commits', githubController.connectOctokit, githubController.getCommits, (req, res) => {
-    res.status(200).json(res.locals.commits);
-});
+// accepts owner and repoName and gets commit history data (messages and patches of code)
+githubRouter.post('/commits', 
+  authController.verify,
+  githubController.connectOctokit, 
+  githubController.getCommits, 
+  (req, res) => res.status(200).json(res.locals.commits));
 
 export { githubRouter };

--- a/server/routes/githubRouter.js
+++ b/server/routes/githubRouter.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { githubController } from '../controllers/githubController.js';
+
+const githubRouter = express.Router();
+
+githubRouter.post('/commits', githubController.connectOctokit, githubController.getCommits, (req, res) => {
+    res.status(200).json(res.locals.commits);
+});
+
+export { githubRouter };

--- a/server/server.js
+++ b/server/server.js
@@ -39,6 +39,18 @@ app.get('/', (req, res) => {
   res.send('Home page');
 });
 
+// global error handler
+app.use((err, req, res, next) => {
+  const defaultErr = {
+    log: 'Express error handler caught unknown middleware error',
+    status: 500,
+    message: { err: 'An error occurred' }
+  };
+  const errorObj = Object.assign({}, defaultErr, err);
+  console.log(errorObj.log);
+  res.status(errorObj.status).json(errorObj.message);
+});
+
 app.listen(PORT, () => {
   console.log(`Server is listening on http://localhost:${PORT}`);
   console.log('\n\n');

--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ import session from 'express-session';
 import { config } from 'dotenv';
 
 import { authRouter } from './routes/authRouter.js';
+import { githubRouter } from './routes/githubRouter.js';
 
 config();
 const ghClientId = process.env.GH_CLIENT_ID;
@@ -12,6 +13,8 @@ const sessionSecret = process.env.SESSION_SECRET;
 
 const app = express();
 const PORT = 3000;
+
+app.use(express.json());
 
 // session middleware is used to store info about the user
 // in a 'session object' which is stored on the server
@@ -29,6 +32,8 @@ app.use(session({
 }));
 
 app.use('/api/auth/', authRouter);
+
+app.use('/api/github', githubRouter);
 
 app.get('/', (req, res) => {
   res.send('Home page');


### PR DESCRIPTION
1) Added a new route to the server.js '/api/github' and githubRouter to handle requests related to retrieving data from GitHub API.
2) A POST request to '/api/github/commits' triggers a series of controllers. POST requests expects to receive 'owner' and 'repoName' from req.body. I expect 'repoName' to come from UI click event, but we need to discuss how to get the 'owner' - possibly through authentication process.
Controllers do:
- verify that authentication token exist, to protect the route;
- connect to Octokit which is mandatory to interact with GitHub API;
- query commits metadata from GitHub API, which is essentially a list of objects, each of which contains data about the commit. This list then filtered out to exclude all commit messages starting from the word "Merge" to exclude automatic merge commits and reduce the number of consequent queries to API. Next, for each commit in the filtered list, we request more data, namely the code patches associated with each commit. The requests for code patches are handled in parallel using Promise.all. Current implementation ensures that even if a request to 1 commit has bad response, the Promise.all still resolves with all other valid commits (to be discussed if this is what we want).
3) Added global error handler to server.js. 