### PR TITLE
code: per-session storage => cookie storage. githubService.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ dist
 *.psql
 
 custom-es-config*
+
+data/user/*

--- a/client/components/AuthComp.tsx
+++ b/client/components/AuthComp.tsx
@@ -11,7 +11,7 @@ const AuthComp: React.FC = () => {
     const tokenBool: boolean = await response.json();
 
     if (!tokenBool) {
-      console.log('authController: Failed to get token');
+      console.log('authC: No token present. Redirecting to github login...');
       const redirectURI = `https://github.com/login/oauth/authorize?client_id=${ghClientId}`;
       // if window is full screen, open in a new window, which is to say a new tab bc fullscreen.
       if (window.matchMedia('(display-mode: fullscreen)').matches) {
@@ -37,7 +37,7 @@ const AuthComp: React.FC = () => {
   }, []);
 
   const handleMessage = (event: MessageEvent) => {
-    // the value of event.data is set in authController.closeGhLogin
+    // the value of event.data is set in authC.closeGhLogin
     if (event.origin === window.location.origin && event.data === 'closeGhLogin') {
       console.log('Authorization complete');
 

--- a/client/components/AuthComp.tsx
+++ b/client/components/AuthComp.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useEffect } from 'react';
 
+const ghClientId = process.env.REACT_APP_GH_CLIENT_ID;
+
 const AuthComp: React.FC = () => {
   let authWindow: Window | null;
 
@@ -9,12 +11,17 @@ const AuthComp: React.FC = () => {
     const tokenBool: boolean = await response.json();
 
     if (!tokenBool) {
+      console.log('authController: Failed to get token');
+      const redirectURI = `https://github.com/login/oauth/authorize?client_id=${ghClientId}`;
       // if window is full screen, open in a new window, which is to say a new tab bc fullscreen.
       if (window.matchMedia('(display-mode: fullscreen)').matches) {
-        authWindow = window.open('/api/auth/login/gh', '_blank');
+        authWindow = window.open(redirectURI, '_blank');
+        // second parameter is the name of the window.
+        // _blank means that the URL should be loaded into a new window.
       } else {
         // otherwise pop up
-        authWindow = window.open('/api/auth/login/gh', '_blank', 'width=800,height=600,,toolbar=no,scrollbars=no,status=no,resizable=no,location=no,menuBar=no,left=500,top=100');
+        authWindow = window.open(redirectURI, '_blank', 'width=800,height=600,,toolbar=no,scrollbars=no,status=no,resizable=no,location=no,menuBar=no,left=500,top=100');
+        // third parameter is the properties of the window. This creates a popup window.
       }
 
       return;

--- a/client/components/VerifyTestComp.tsx
+++ b/client/components/VerifyTestComp.tsx
@@ -1,33 +1,33 @@
 import React from 'react';
 import { useState } from 'react';
 
-const VerifyTokenTestComp: React.FC = () => {
+const VerifyTestComp: React.FC = () => {
   const [tokenExists, setTokenExists] = useState(false);
   const [clickBool, setclickBool] = useState(false);
 
   const handleClick = async (): Promise<void> => {
 
-    const response = await fetch('/api/auth/verifyTokenTest');
+    const response = await fetch('/api/auth/verifyTest');
     const data: boolean = await response.json();
     setTokenExists(data ? true : false);
     setclickBool(true);
 
     if (!data) {
-      console.log('VerifyTokenTestComp: Failed to verify token');
+      console.log('VerifyTestComp: Failed to verify token');
       return;
     }
-    console.log('VerifyTokenTestComp: Verified token');
+    console.log('VerifyTestComp: Verified token');
   };
 
   return (
     <div>
       <button className="btn" style={{ fontSize: '2rem', marginTop: '.625rem', marginLeft: 'auto', marginRight: 'auto', display: 'block', width: '100%', backgroundColor: clickBool && tokenExists === false ? 'maroon' : clickBool && tokenExists === true ? 'green' : undefined }}
         onClick={handleClick}
-      >token? {clickBool ? (tokenExists ? ' ✔️ ' : ' 🙅‍♂️ ') : null }</button>
+      >token? {clickBool ? (tokenExists ? ' ✔️ ' : ' ❌ ') : null }</button>
     </div>
   );
 
 };
 
 
-export { VerifyTokenTestComp };
+export { VerifyTestComp };

--- a/client/components/VerifyTestComp.tsx
+++ b/client/components/VerifyTestComp.tsx
@@ -4,26 +4,70 @@ import { useState } from 'react';
 const VerifyTestComp: React.FC = () => {
   const [tokenExists, setTokenExists] = useState(false);
   const [clickBool, setclickBool] = useState(false);
+  const [owner, setOwner] = useState('');
+  const [repoName, setRepoName] = useState('');
 
-  const handleClick = async (): Promise<void> => {
+  const handleClickToken = async (): Promise<void> => {
 
     const response = await fetch('/api/auth/verifyTest');
-    const data: boolean = await response.json();
-    setTokenExists(data ? true : false);
+    const status: number = response.status;
+    setTokenExists(status === 200 ? true : false);
     setclickBool(true);
 
-    if (!data) {
-      console.log('VerifyTestComp: Failed to verify token');
+    if (status !== 200) {
+      console.log('VerifyTestComp: ❌');
       return;
     }
-    console.log('VerifyTestComp: Verified token');
+    console.log('VerifyTestComp: ✅');
+  };
+
+  const handleOwnerChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setOwner(e.target.value);
+  }
+
+  const handleRepoNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRepoName(e.target.value);
+  }
+
+  const handleClickGetCommits = async (): Promise<void> => {
+
+    const response = await fetch('/api/github/commits', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ owner, repoName }),
+    });
+    try {
+      const data = await response.json();
+      if (data) {
+        console.log('VerifyTestComp: data', data);
+      }
+    } catch (error) {
+      console.log('VerifyTestComp: error', error);
+    }
   };
 
   return (
     <div>
-      <button className="btn" style={{ fontSize: '2rem', marginTop: '.625rem', marginLeft: 'auto', marginRight: 'auto', display: 'block', width: '100%', backgroundColor: clickBool && tokenExists === false ? 'maroon' : clickBool && tokenExists === true ? 'green' : undefined }}
-        onClick={handleClick}
-      >token? {clickBool ? (tokenExists ? ' ✔️ ' : ' ❌ ') : null }</button>
+      <div>
+        <button className="btn" style={{ fontSize: '1.5rem', marginTop: '.25rem', marginLeft: 'auto', marginRight: 'auto', display: 'block', width: '100%', backgroundColor: clickBool && tokenExists === false ? 'maroon' : clickBool && tokenExists === true ? 'green' : undefined }}
+          onClick={handleClickToken}
+        >token? {clickBool ? (tokenExists ? ' ✔️ ' : ' ❌ ') : null}</button>
+      </div>
+      <br />
+      < hr />
+      <br />
+      <div>
+        <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
+          <input className="form" type="text" placeholder="owner" onChange={handleOwnerChange} style={{ flex: '1' }} />
+          <input className="form" type="text" placeholder="repoName" onChange={handleRepoNameChange} style={{ flex: '1' }} />
+        </div>
+        <br />
+        <button className="btn" style={{ fontSize: '1.5rem', marginTop: '.25rem', marginLeft: 'auto', marginRight: 'auto', display: 'block', width: '100%' }}
+          onClick={handleClickGetCommits}
+        >get commits</button>
+      </div>
     </div>
   );
 

--- a/client/components/VerifyTokenTestComp.tsx
+++ b/client/components/VerifyTokenTestComp.tsx
@@ -9,26 +9,25 @@ const VerifyTokenTestComp: React.FC = () => {
 
     const response = await fetch('/api/auth/verifyTokenTest');
     const data: boolean = await response.json();
-    setTokenExists(data);
-
+    setTokenExists(data ? true : false);
     setclickBool(true);
 
     if (!data) {
-      console.log('Token does not exist');
+      console.log('VerifyTokenTestComp: Failed to verify token');
       return;
     }
-
-    console.log('Token exists');
+    console.log('VerifyTokenTestComp: Verified token');
   };
 
   return (
     <div>
-      <button className="btn" style={{ fontSize: '2rem', marginTop: '.625rem', marginLeft: 'auto', marginRight: 'auto', display: 'block', width: '100%', backgroundColor: clickBool && tokenExists === true ? 'green' : clickBool && tokenExists === false ? 'maroon' : undefined }}
+      <button className="btn" style={{ fontSize: '2rem', marginTop: '.625rem', marginLeft: 'auto', marginRight: 'auto', display: 'block', width: '100%', backgroundColor: clickBool && tokenExists === false ? 'maroon' : clickBool && tokenExists === true ? 'green' : undefined }}
         onClick={handleClick}
       >token? {clickBool ? (tokenExists ? ' ✔️ ' : ' 🙅‍♂️ ') : null }</button>
     </div>
   );
 
 };
+
 
 export { VerifyTokenTestComp };

--- a/client/pages/LandingPage.tsx
+++ b/client/pages/LandingPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AuthComp } from '../components/AuthComp';
-import { VerifyTokenTestComp } from '../components/VerifyTokenTestComp';
+import { VerifyTestComp } from '../components/VerifyTestComp';
 
 const LandingPage: React.FC = () => {
   return (
@@ -18,7 +18,7 @@ const LandingPage: React.FC = () => {
           <br/>
           <hr/>
           <br/>
-          <VerifyTokenTestComp />
+          <VerifyTestComp />
         </div>
       </div>
   );

--- a/client/stylesheets/scss/styles.scss
+++ b/client/stylesheets/scss/styles.scss
@@ -82,3 +82,25 @@ code {
   font-weight: bold;
   text-decoration: underline;
 }
+
+.form {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  max-width: 600px;
+  background: #32353c;
+  padding: 8px;
+  border-radius: 10px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(10px);
+  color: #ffffff;
+
+  input {
+    width: 100%;
+    padding: 10px;
+    border-radius: 10px;
+    border: none;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,15 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
+        "@octokit/core": "^6.1.2",
+        "@octokit/oauth-app": "^7.1.2",
+        "cookie-parser": "^1.4.6",
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-session": "^1.17.3",
+        "jsonwebtoken": "^9.0.2",
+        "node-fetch": "^3.3.2",
         "octokit": "^4.0.2"
       },
       "devDependencies": {
@@ -19,8 +27,6 @@
         "@babel/preset-env": "^7.24.6",
         "@babel/preset-react": "^7.24.6",
         "@babel/preset-typescript": "^7.24.6",
-        "@octokit/core": "^6.1.2",
-        "@octokit/oauth-app": "^7.1.2",
         "@reduxjs/toolkit": "^2.2.5",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.13",
@@ -31,17 +37,13 @@
         "babel-loader": "^9.1.3",
         "concurrently": "^8.2.2",
         "copy-webpack-plugin": "^12.0.2",
-        "cors": "^2.8.5",
         "css-loader": "^7.1.2",
-        "dotenv": "^16.4.5",
         "eslint": "^9.3.0",
         "esm": "^3.2.25",
-        "express-session": "^1.18.0",
         "fork-ts-checker-webpack-plugin": "^9.0.2",
         "highlight.js": "^11.9.0",
         "html-webpack-plugin": "^5.6.0",
         "modern-normalize": "^2.0.0",
-        "node-fetch": "^3.3.2",
         "nodemon": "^3.1.2",
         "normalize.css": "^8.0.1",
         "postcss": "^8.4.38",
@@ -3860,6 +3862,11 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3936,9 +3943,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001625",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001625.tgz",
-      "integrity": "sha512-4KE9N2gcRH+HQhpeiRZXd+1niLB/XNLAhSy4z7fI8EzcbcPoAqjNInxVHTiTwWfTIV4w096XG8OtCOCQQKPv3w==",
+      "version": "1.0.30001626",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001626.tgz",
+      "integrity": "sha512-JRW7kAH8PFJzoPCJhLSHgDgKg5348hsQ68aqb+slnzuB5QFERv846oA/mRChmlLAOdEDeOkRn3ynb1gSFnjt3w==",
       "dev": true,
       "funding": [
         {
@@ -4411,11 +4418,23 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/cookie-signature": {
@@ -4470,7 +4489,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -4644,7 +4662,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -4911,7 +4928,6 @@
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
       "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -4925,15 +4941,23 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.787",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.787.tgz",
-      "integrity": "sha512-d0EFmtLPjctczO3LogReyM2pbBiiZbnsKnGF+cdZhsYzHm/A0GV7W94kqzLD8SN4O3f3iHlgLUChqghgyznvCQ==",
+      "version": "1.4.788",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.788.tgz",
+      "integrity": "sha512-ubp5+Ev/VV8KuRoWnfP2QF2Bg+O2ZFdb49DiiNbz2VmgkIqrnyYaqIOqj8A6K/3p1xV0QcU5hBQ1+BmB6ot1OA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -5376,7 +5400,6 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.0.tgz",
       "integrity": "sha512-m93QLWr0ju+rOwApSsyso838LQwgfs44QtOP/WBiwtAgPIo/SAh1a5c6nn2BR6mFNZehTpqKDESzP+fRHVbxwQ==",
-      "dev": true,
       "dependencies": {
         "cookie": "0.6.0",
         "cookie-signature": "1.0.7",
@@ -5391,17 +5414,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/express-session/node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "dev": true
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
     },
     "node_modules/express-session/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -5409,8 +5438,15 @@
     "node_modules/express-session/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -5505,7 +5541,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5806,7 +5841,6 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -7034,6 +7068,57 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7138,17 +7223,46 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -7371,8 +7485,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -7456,7 +7569,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7475,7 +7587,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -7596,7 +7707,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7659,7 +7769,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -8468,7 +8577,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
       "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -8738,9 +8846,9 @@
       "dev": true
     },
     "node_modules/reselect": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
-      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "dev": true
     },
     "node_modules/resolve": {
@@ -10584,7 +10692,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
       "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "dev": true,
       "dependencies": {
         "random-bytes": "~1.0.0"
       },
@@ -10800,7 +10907,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
     "@babel/preset-env": "^7.24.6",
     "@babel/preset-react": "^7.24.6",
     "@babel/preset-typescript": "^7.24.6",
-    "@octokit/core": "^6.1.2",
-    "@octokit/oauth-app": "^7.1.2",
     "@reduxjs/toolkit": "^2.2.5",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.13",
@@ -50,17 +48,13 @@
     "babel-loader": "^9.1.3",
     "concurrently": "^8.2.2",
     "copy-webpack-plugin": "^12.0.2",
-    "cors": "^2.8.5",
     "css-loader": "^7.1.2",
-    "dotenv": "^16.4.5",
     "eslint": "^9.3.0",
     "esm": "^3.2.25",
-    "express-session": "^1.18.0",
     "fork-ts-checker-webpack-plugin": "^9.0.2",
     "highlight.js": "^11.9.0",
     "html-webpack-plugin": "^5.6.0",
     "modern-normalize": "^2.0.0",
-    "node-fetch": "^3.3.2",
     "nodemon": "^3.1.2",
     "normalize.css": "^8.0.1",
     "postcss": "^8.4.38",
@@ -89,7 +83,15 @@
     "webpack-dev-server": "^5.0.4"
   },
   "dependencies": {
+    "@octokit/core": "^6.1.2",
+    "@octokit/oauth-app": "^7.1.2",
+    "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-session": "^1.17.3",
+    "jsonwebtoken": "^9.0.2",
+    "node-fetch": "^3.3.2",
     "octokit": "^4.0.2"
   }
 }

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -1,5 +1,11 @@
 import { config } from 'dotenv';
 import fetch from 'node-fetch';
+import jwt from 'jsonwebtoken';
+
+import { getUserDataBasic, getUserDataDetailed } from '../services/githubService.js';
+
+// set this to false if you don't want to get detailed user data.
+const getUserDataDetailedBool = true;
 
 const authController = {};
 
@@ -7,21 +13,22 @@ config();
 
 const ghClientId = process.env.GH_CLIENT_ID;
 const ghClientSecret = process.env.GH_CLIENT_SECRET;
+const secretKey = process.env.SECRET_KEY;
 
 // the controller to call to check if token exists
 authController.verify = async (req, res, next) => {
-  if (req.session.accessToken) {
-    console.log('authController.verify: accessToken:', req.session.accessToken);
-    next();
-
-  } else {
-    console.log('authController.verify: no accessToken');
+  // console.log('authController: verify');
+  const token = req.cookies.token;
+  if (!token) {
+    console.log('authController.verify: no token');
     res.json(false);
+  } else {
+    console.log('authController.verify: token exists');
+    next();
   }
 };
 
-authController.loginGh = async (req, res, next) => {
-  // prompt=consent&
+authController.login = async (req, res, next) => {
   try {
     const redirectURI = `https://github.com/login/oauth/authorize?client_id=${ghClientId}`;
     res.redirect(redirectURI);
@@ -32,14 +39,14 @@ authController.loginGh = async (req, res, next) => {
 };
 
 // this is called after the user has authenticated
-authController.handleGhCallback = async (req, res, next) => {
+authController.tokenGet = async (req, res, next) => {
   // console.log('authController: handleCallback');
   try {
-    const { code } = req.query;
+    const { code } = req.query; // destructuring. same as const code = req.query.code;
     if (!code) {
       return res.status(400).send('Code not provided');
     }
-    req.session.accessCode = code;
+
     // console.log('authController: code retrieved from github oauth', code);
     // the request to exchange the code for an access token
     const response = await fetch('https://github.com/login/oauth/access_token', {
@@ -65,40 +72,73 @@ authController.handleGhCallback = async (req, res, next) => {
       return res.status(400).send('accessToken not retrieved');
     }
 
-    console.log('authController: accessToken retrieved, stored in session', accessToken);
+    const userDataBasic = await getUserDataBasic(accessToken);
+    if (userDataBasic) {
+      console.log('authController: user retrieved from github', userDataBasic.login);
+    }
 
-    // Store the token in session, by way of express-session
-    req.session.accessToken = accessToken;
+    if (userDataBasic.login && getUserDataDetailedBool) {
+      await getUserDataDetailed(accessToken, userDataBasic.login);
+    }
 
-    return next();
+    const tokenPayload = { accessToken: accessToken, userDataBasic: userDataBasic, userAuth: true };
+
+    const token = jwt.sign(tokenPayload, secretKey, { expiresIn: '30m' });
+    res.cookie('token', token, {
+      // if true, cookie is not accessible from javascript, only from the server. this is to prevent XSS attacks.
+      httpOnly: true,
+      // if true, cookies will only be transmitted over https. Use true when deploying to production
+      secure: false,
+      // 'strict': the cookie will only be sent in a request if the request is made from the same site origin.
+      // cookie added to example.com:
+      // req(example.com/site) === true
+      // req(blog.example.com) === false
+
+      // 'lax': the cookie will be sent in a request if the request is made from the same site origin or the first-party origin is a subdomain of the site origin.
+      // req(example.com/site) === true
+      // req(blog.example.com) === true
+      sameSite: 'strict',
+    });
+
+    next();
   } catch (error) {
     console.log(error);
     res.status(500).send('An error occurred');
   }
-};
+}
 
-authController.loginGhClose = (req, res, next) => {
-
-console.log('authController: loginGhClose');
-// next();
+authController.loginClose = (req, res, next) => {
+  console.log('authController: loginGhClose');
+  // next();
   res.send(`
     <script>
       window.opener.postMessage('loginGhClose', '${req.protocol}://${req.get('host')}');
       window.close();
     </script>
   `);
-
-  // return
 };
 
 authController.verifyTokenTestPassed = (req, res, next) => {
-  console.log('authController.verified: token verified.');
-  // next();
-  res.send(true);
+  console.log('authController.verifyTokenTestPassed: token verified.');
+  // const token = req.cookies.token;
+    // another example of storing user data in the cookie, this time after verifying the token
+    // jwt.verify(token, secretKey, (err, payload) => {
+    //   if (err) return res.sendStatus(403);
+    //   req.user = payload;
+    //   // next();
+    // });
+    // // next();
+    // res.send(req.user);
+    res.json(true);
 }
 
-authController.ghLogout = async (req, res, next) => {
-  // prompt=consent&: // this prompts the reauthorization screen of github
+authController.tokenDelete = (req, res, next) => {
+  console.log('authController: tokenDelete');
+  res.clearCookie('token');
+  next();
+};
+
+authController.logout = async (req, res, next) => {
   try {
     const redirectURI = `https://github.com/login/oauth/authorize?prompt=consent&scope=repo&client_id=${ghClientId}`;
     res.redirect(redirectURI);
@@ -106,7 +146,9 @@ authController.ghLogout = async (req, res, next) => {
     console.log(error);
     res.status(500).send('An error occurred');
   }
+  next();
 };
+
 
 authController.error = (req, res, next) => {
   console.log('authController: error');

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -16,14 +16,27 @@ const ghClientSecret = process.env.GH_CLIENT_SECRET;
 const secretKey = process.env.SECRET_KEY;
 
 // the controller to call to check if token exists
+
 authController.verify = async (req, res, next) => {
   // console.log('authController: verify');
   const token = req.cookies.token;
+  // console.log('authController.verify: token', token);
+
   if (!token) {
     console.log('authController.verify: no token');
     res.json(false);
   } else {
+    // decode the token (without verification) to quickly access its contents
+    const decoded = jwt.decode(token, { complete: true });
+
+    // access specific parts of the decoded token
+    const payload = decoded.payload; // the main content of the token
+    const header = decoded.header; // the header of the token
     console.log('authController.verify: token exists');
+
+    const usernameDecoded = payload.username;
+    const tokenDecoded = payload.token;
+    console.log('authController.verify: usernameDecoded', usernameDecoded);
     next();
   }
 };
@@ -81,7 +94,7 @@ authController.tokenGet = async (req, res, next) => {
       await getUserDataDetailed(accessToken, userDataBasic.login);
     }
 
-    const tokenPayload = { accessToken: accessToken, userDataBasic: userDataBasic, userAuth: true };
+    const tokenPayload = { accessToken: accessToken, userDataBasic: userDataBasic, userAuth: true, username: userDataBasic.login };
 
     const token = jwt.sign(tokenPayload, secretKey, { expiresIn: '30m' });
     res.cookie('token', token, {
@@ -121,15 +134,11 @@ authController.loginClose = (req, res, next) => {
 authController.verifyTokenTestPassed = (req, res, next) => {
   console.log('authController.verifyTokenTestPassed: token verified.');
   // const token = req.cookies.token;
-    // another example of storing user data in the cookie, this time after verifying the token
-    // jwt.verify(token, secretKey, (err, payload) => {
-    //   if (err) return res.sendStatus(403);
-    //   req.user = payload;
-    //   // next();
-    // });
-    // // next();
-    // res.send(req.user);
-    res.json(true);
+  // another example of storing user data in the cookie, this time after verifying the token
+
+  // // next();
+  // res.send(req.user);
+  res.json(true);
 }
 
 authController.tokenDelete = (req, res, next) => {

--- a/server/controllers/githubController.js
+++ b/server/controllers/githubController.js
@@ -22,18 +22,9 @@ githubController.connectOctokit = (req, res, next) => {
   //   type: 'receiving token data',
   //   err: 'Invalid data received'
   // }));
-    const decodedJwt = jwt.decode(user, { complete: true });
-
-    // access specific parts of the decoded token
-    const payload = decodedJwt.payload; // the main content of the token
-    const header = decodedJwt.header; // the header of the token
-    console.log('authController.verify: token exists');
-
-    const tokenDecoded = payload.token;
-    const usernameDecoded = payload.username;
 
   const octokit = new Octokit({
-    auth: req.cookies.user.token
+    auth: req.user.token
   });
   res.locals.octokit = octokit;
   next();
@@ -42,6 +33,8 @@ githubController.connectOctokit = (req, res, next) => {
 // gets the list of all commits for a particular repo for a particular author
 githubController.getCommits = async (req, res, next) => {
   const { owner, repoName } = req.body;
+
+  console.log('GET COMMITS: owner', owner, 'repoName', repoName);
 
   // check for missing data
   if (!owner || !repoName) return next(createErr({

--- a/server/controllers/githubController.js
+++ b/server/controllers/githubController.js
@@ -16,8 +16,8 @@ const githubController = {};
 // create an instance of octokit (octokit is used to interact with the GitHub REST API in JS scripts)
 githubController.connectOctokit = (req, res, next) => {
   // check for missing data
-  // console.log('CONNECT OCTOKIT: TOKEN:   ', req.cookies.user.token);
-  // if (!req.cookies.user.token) return next(createErr({
+  // console.log('CONNECT OCTOKIT: TOKEN:   ', req.user.token);
+  // if (!req.user.token) return next(createErr({
   //   method: 'connectOctokit',
   //   type: 'receiving token data',
   //   err: 'Invalid data received'

--- a/server/routes/authRouter.js
+++ b/server/routes/authRouter.js
@@ -13,13 +13,17 @@ authRouter.get('/login', authController.verify, (req, res) => {
 });
 
 // if login^ returns true, this then gets called by the front end.
-authRouter.get('/login/gh', authController.loginGh);
+authRouter.get('/login/gh', authController.login);
 
 // Handle GitHub callback and exchange code for access token
 // this is the endpoint provided to github in the oauth setup.
 // that is, 'http://localhost:8080/api/auth/call'
-authRouter.get('/call', authController.handleGhCallback, authController.loginGhClose);
+authRouter.get('/call', authController.tokenGet, authController.loginClose);
 
 authRouter.get('/verifyTokenTest', authController.verify, authController.verifyTokenTestPassed);
+
+// logout
+// not yet implemented on the front end
+authRouter.get('/logout', authController.tokenDelete, authController.logout);
 
 export { authRouter };

--- a/server/routes/authRouter.js
+++ b/server/routes/authRouter.js
@@ -12,18 +12,16 @@ authRouter.get('/login', authController.verify, (req, res) => {
   res.send(false);
 });
 
-// if login^ returns true, this then gets called by the front end.
-authRouter.get('/login/gh', authController.login);
 
 // Handle GitHub callback and exchange code for access token
 // this is the endpoint provided to github in the oauth setup.
 // that is, 'http://localhost:8080/api/auth/call'
-authRouter.get('/call', authController.tokenGet, authController.loginClose);
+authRouter.get('/call', authController.tokenGet, authController.cookiesSet);
 
-authRouter.get('/verifyTokenTest', authController.verify, authController.verifyTokenTestPassed);
+authRouter.get('/verifyTest', authController.verify, authController.verifyTest);
 
 // logout
 // not yet implemented on the front end
-authRouter.get('/logout', authController.tokenDelete, authController.logout);
+authRouter.get('/logout', authController.cookiesClear, authController.logout);
 
 export { authRouter };

--- a/server/routes/authRouter.js
+++ b/server/routes/authRouter.js
@@ -1,9 +1,9 @@
 import express from 'express';
-import { authController } from '../controllers/authController.js';
+import { authC } from '../controllers/authController.js';
 
 const authRouter = express.Router();
 
-authRouter.get('/login', authController.verify, (req, res) => {
+authRouter.get('/login', authC.verify, (req, res) => {
   // this will be called only if verify returns next()
   res.send(true);
 }, (err, req, res, next) => {
@@ -16,12 +16,12 @@ authRouter.get('/login', authController.verify, (req, res) => {
 // Handle GitHub callback and exchange code for access token
 // this is the endpoint provided to github in the oauth setup.
 // that is, 'http://localhost:8080/api/auth/call'
-authRouter.get('/call', authController.tokenGet, authController.cookiesSet);
+authRouter.get('/call', authC.tokenGet, authC.cookiesSet);
 
-authRouter.get('/verifyTest', authController.verify, authController.verifyTest);
+authRouter.get('/verifyTest', authC.verify, authC.verifyTest);
 
 // logout
 // not yet implemented on the front end
-authRouter.get('/logout', authController.cookiesClear, authController.logout);
+authRouter.get('/logout', authC.cookiesClear, authC.logout);
 
 export { authRouter };

--- a/server/routes/githubRouter.js
+++ b/server/routes/githubRouter.js
@@ -1,14 +1,14 @@
 import express from 'express';
 import { githubController } from '../controllers/githubController.js';
-import { authController } from '../controllers/authController.js';
+import { authC } from '../controllers/authController.js';
 
 const githubRouter = express.Router();
 
 // accepts owner and repoName and gets commit history data (messages and patches of code)
-githubRouter.post('/commits', 
-  authController.verify,
-  githubController.connectOctokit, 
-  githubController.getCommits, 
+githubRouter.post('/commits',
+  authC.verify,
+  githubController.connectOctokit,
+  githubController.getCommits,
   (req, res) => res.status(200).json(res.locals.commits));
 
 export { githubRouter };

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@
 import express from 'express';
 import session from 'express-session';
 import { config } from 'dotenv';
+import cookieParser from 'cookie-parser';
 
 import { authRouter } from './routes/authRouter.js';
 import { githubRouter } from './routes/githubRouter.js';
@@ -9,27 +10,20 @@ import { githubRouter } from './routes/githubRouter.js';
 config();
 const ghClientId = process.env.GH_CLIENT_ID;
 const ghClientSecret = process.env.GH_CLIENT_SECRET;
-const sessionSecret = process.env.SESSION_SECRET;
+const secretKey = process.env.SECRET_KEY;
 
 const app = express();
 const PORT = 3000;
 
 app.use(express.json());
+app.use(cookieParser());
 
-// session middleware is used to store info about the user
-// in a 'session object' which is stored on the server
-// and identified by a unique cookie in the user's browser.
-// When the user makes a request, the cookie is sent to the server
-// and the server uses the cookie to access the session object.
-// The session object is stored in memory by default, but it can
-// be configured to store in a database or other storage system.
-
-app.use(session({
-  secret: sessionSecret, // a secret string used to encrypt the session cookie
-  resave: false, // if true, store session data in server memory.
-  saveUninitialized: false, // if true, save a session to the store even if it is not modified
-  cookie: { secure: false } // if true, cookies will only be transmitted over https. Use when deploying to production
-}));
+// app.use(session({
+//   secret: sessionSecret, // a secret string used to encrypt the session cookie
+//   resave: false, // if true, store session data in server memory.
+//   saveUninitialized: false, // if true, save a session to the store even if it is not modified
+//   cookie: { secure: false } // if true, cookies will only be transmitted over https. Use when deploying to production
+// }));
 
 app.use('/api/auth/', authRouter);
 

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -10,7 +10,7 @@ export const tokenGet = async (code) => {
     console.log('authService: code not provided, returning code not provided');
     return res.status(400).send('Code not provided');
   }
-  // console.log('authController: code retrieved from github oauth', code);
+  // console.log('authC: code retrieved from github oauth', code);
   // the request to exchange the code for an access token
   const response = await fetch('https://github.com/login/oauth/access_token', {
     method: 'POST',
@@ -27,16 +27,7 @@ export const tokenGet = async (code) => {
 
   // the access token from github
   const { access_token } = await response.json();
-  console.log('authController: access token', access_token);
+  // console.log('authService: token', access_token);
   return access_token;
 
-}
-
-export const loginGet = async (req, res) => {
-  const redirectURI = `https://github.com/login/oauth/authorize?client_id=${ghClientId}`;
-  const response = await fetch(redirectURI);
-  // const { url } = await response.json();
-  console.log('loginGet: response', response);
-  console.log('loginGet: url', url);
- return await response.json();
 }

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -1,0 +1,42 @@
+import fetch from 'node-fetch';
+import { config } from 'dotenv';
+config();
+
+const ghClientId = process.env.GH_CLIENT_ID;
+const ghClientSecret = process.env.GH_CLIENT_SECRET;
+
+export const tokenGet = async (code) => {
+  if (!code) {
+    console.log('authService: code not provided, returning code not provided');
+    return res.status(400).send('Code not provided');
+  }
+  // console.log('authController: code retrieved from github oauth', code);
+  // the request to exchange the code for an access token
+  const response = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: ghClientId,
+      client_secret: ghClientSecret,
+      code,
+    }),
+  });
+
+  // the access token from github
+  const { access_token } = await response.json();
+  console.log('authController: access token', access_token);
+  return access_token;
+
+}
+
+export const loginGet = async (req, res) => {
+  const redirectURI = `https://github.com/login/oauth/authorize?client_id=${ghClientId}`;
+  const response = await fetch(redirectURI);
+  // const { url } = await response.json();
+  console.log('loginGet: response', response);
+  console.log('loginGet: url', url);
+ return await response.json();
+}

--- a/server/services/githubService.js
+++ b/server/services/githubService.js
@@ -1,0 +1,77 @@
+import fetch from 'node-fetch';
+import { writeFileSync, mkdir } from 'node:fs';
+
+// set this to false if you dont want to write said data to files. (we're only doing this with our own data.)
+const writeFSUserDataDetailedBool = true;
+
+const getUserDataDetailed = async (token, username) => {
+  mkdir((new URL('../../data/user/', import.meta.url)), { recursive: true }, (err) => {
+    if (err) throw err;
+  });
+
+  const ghApiEndpoints = {
+    subscriptions: 'subscriptions',
+    received_events: 'received_events',
+    events: 'events',
+    orgs: 'orgs',  // not returning anything for Keith atm
+    repos: 'repos',  // not returning anything for Keith atm
+    gists: 'gists', // not returning anything for Keith atm
+  };
+
+  const fetchData = async (key, value) => {
+    const url = `https://api.github.com/users/${username}/${value}`
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+    });
+    if (!response.ok) {
+      throw new Error('Failed to fetch user data');
+    }
+    const ghData = await response.json();
+
+    if (writeFSUserDataDetailedBool) {
+      writeFileSync(`./data/user/${key}`, JSON.stringify(ghData, null, 2));
+    }
+  }
+
+  for (let [key, value] of Object.entries(ghApiEndpoints)) {
+    try {
+      console.log('authController: getGhData:', key, value);
+      await fetchData(key, value);
+
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+};
+
+const getUserDataBasic = async (accessToken) => {
+  // console.log('authController: getUserInfo: accessToken', accessToken);
+  const response = await fetch('https://api.github.com/user', {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch user information');
+  }
+
+  const userData = await response.json();
+  // recursive = true: if the folder already exists, it doesn't throw an error
+  mkdir((new URL('../../data/user/', import.meta.url)), { recursive: true }, (err) => {
+    if (err) throw err;
+  });
+
+  writeFileSync(`./data/user/info`, JSON.stringify(userData, null, 2));
+  // console.log('authController: getUserInfo: userData', userData);
+  return userData;
+}
+
+export { getUserDataBasic, getUserDataDetailed };

--- a/server/services/githubService.js
+++ b/server/services/githubService.js
@@ -2,9 +2,9 @@ import fetch from 'node-fetch';
 import { writeFileSync, mkdir } from 'node:fs';
 
 // set this to false if you dont want to write said data to files. (we're only doing this with our own data.)
-const writeFSUserDataDetailedBool = true;
+const writeFSUserDataMegaBool = true;
 
-const getUserDataDetailed = async (token, username) => {
+const getUserDataMega = async (token, username) => {
   mkdir((new URL('../../data/user/', import.meta.url)), { recursive: true }, (err) => {
     if (err) throw err;
   });
@@ -32,7 +32,7 @@ const getUserDataDetailed = async (token, username) => {
     }
     const ghData = await response.json();
 
-    if (writeFSUserDataDetailedBool) {
+    if (writeFSUserDataMegaBool) {
       writeFileSync(`./data/user/${key}`, JSON.stringify(ghData, null, 2));
     }
   }
@@ -49,12 +49,12 @@ const getUserDataDetailed = async (token, username) => {
 
 };
 
-const getUserDataBasic = async (accessToken) => {
-  // console.log('authController: getUserInfo: accessToken', accessToken);
+const getUserDataMeta = async (token) => {
+  // console.log('authController: getUserDataMeta: token', token);
   const response = await fetch('https://api.github.com/user', {
     method: 'GET',
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${token}`,
       Accept: 'application/json',
     },
   });
@@ -74,4 +74,4 @@ const getUserDataBasic = async (accessToken) => {
   return userData;
 }
 
-export { getUserDataBasic, getUserDataDetailed };
+export { getUserDataMeta, getUserDataMega };

--- a/server/services/githubService.js
+++ b/server/services/githubService.js
@@ -39,7 +39,7 @@ const getUserDataMega = async (token, username) => {
 
   for (let [key, value] of Object.entries(ghApiEndpoints)) {
     try {
-      console.log('authController: getGhData:', key, value);
+      console.log('authC: getGhData:', key, value);
       await fetchData(key, value);
 
     } catch (err) {
@@ -50,7 +50,7 @@ const getUserDataMega = async (token, username) => {
 };
 
 const getUserDataMeta = async (token) => {
-  // console.log('authController: getUserDataMeta: token', token);
+  // console.log('authC: getUserDataMeta: token', token);
   const response = await fetch('https://api.github.com/user', {
     method: 'GET',
     headers: {
@@ -70,7 +70,7 @@ const getUserDataMeta = async (token) => {
   });
 
   writeFileSync(`./data/user/info`, JSON.stringify(userData, null, 2));
-  // console.log('authController: getUserInfo: userData', userData);
+  // console.log('authC: getUserInfo: userData', userData);
   return userData;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,14 @@
 export default {
-  purge: ['./client/**/*.{html,js,jsx,ts,tsx}'],
-  darkMode: false, // or 'media' or 'class'
+  // https://tailwindcss.com/docs/upgrade-guide#configure-content-sources
+  content: ['./client/**/*.{html,js,jsx,ts,tsx}'],
+  // https://tailwindcss.com/docs/upgrade-guide#remove-dark-mode-configuration
+  // darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {},
   },
-  variants: {
-    extend: {},
-  },
+  // https://tailwindcss.com/docs/upgrade-guide#remove-variant-configuration
+  // variants: {
+  //   extend: {},
+  // },
   plugins: [],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,5 +83,10 @@ export default {
       quiet: true,
     }),
     new ForkTsCheckerWebpackPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        'REACT_APP_GH_CLIENT_ID': JSON.stringify(process.env.REACT_APP_GH_CLIENT_ID),
+      },
+    }),
   ],
 };


### PR DESCRIPTION
- converted our per-session storage of the returned oauth token to cookie storage, which persists between browser sessions. a much more stable implementation too. can be deleted in dev tools if need be. expires after 30 minutes at the moment. 
- looked for and got back basic data about my github account after i oauth logged in to github. used that to setup a function which returns data from the apis listed in the aforementioned basic data object. It includes Pull Requests and tons of other data. The Events and Events Received files are where youll find most of the data. (
- when we login the above described data is saved to a new directory, /data/user. 
- moved the functions that generate that data to a new file, githubService.js in new dir /services. 
- updated tailwind config to dismiss the warnings in the backend console, in doing so returning it to some of the original settings.
- moved backend dependencies from devDependencies to dependencies.