### PR TITLE
Added Bullet Point screen (frontend)

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
 import RepoDisplay from './pages/RepoDisplay';
+import DataDisplay from './pages/DataDisplay';
 import {SelectedRepoProvider} from './components/SelectedRepoProvider';
 
 const App: React.FC = () => {
@@ -11,6 +12,7 @@ const App: React.FC = () => {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/repodisplay" element={<RepoDisplay />} />
+          <Route path="/bulletpoints" element={<DataDisplay />}/>
         </Routes>
       </div>
     </SelectedRepoProvider>

--- a/client/pages/DataDisplay.tsx
+++ b/client/pages/DataDisplay.tsx
@@ -5,7 +5,11 @@ import { useSelectedRepo } from '../components/SelectedRepoProvider';
 const DataDisplay = () => {
   const { selected } = useSelectedRepo();
   const [bulletPoints, setBulletPoints] = useState([]);
-  console.log('SELECTED:   ', selected);
+  const testBulletPoints = [
+    'Used React to develop an application which mirrors the functionality of Chrome Developer Tools Styles tab but displays source file names and line numbers for all types of CSS styles, enabling faster CSS debugging and development.',
+    'Integrated DOM and CSS domains of Chrome Developer Protocol to communicate directly with browser’s functionality without abstraction layers provided by higher-level libraries and to fetch CSS property data of the target application.',
+    'Implemented Redux Toolkit, using Immer and Redux thunks to simplify state management across multiple React components, handle asynchronous HTTP and API requests, ensure immutable state update and efficient data flow.'
+  ];
 
   useEffect(() => {
     console.log('Fetching bullet points data...');
@@ -15,12 +19,17 @@ const DataDisplay = () => {
       body: JSON.stringify({ repoName: selected })
     })
       .then(res => res.json())
-      .then(data => {
-        console.log('DATA DISPLAY COMPONENT: FETCHED DATA:   ', data);
-        setBulletPoints(data);
-      })
+      .then(data => setBulletPoints(data.bulletPoints))
       .catch(err => console.error(`Error fetching bullet points for repo ${selected}. Error: ${err}`))
   }, []);
+
+  const bulletPointElements = testBulletPoints.map((bp, idx) => (
+    <li key={`bullet-point-${idx}`} className='text-white my-4'>{bp}</li>
+  ));
+
+  const handleCopyToClipboardClick = () => {
+    console.log('Copy to clipboard btn has been clicked!');
+  };
 
   return (
     <div>
@@ -31,23 +40,15 @@ const DataDisplay = () => {
       <main className='flex items-center justify-center h-screen bg-blackGR'>
         <div className='bg-darkGrayGR w-3/4 h-4/6 rounded-3xl pt-7 px-10 font-sans flex flex-col items-center justify-between'>
           <div>
-            <h1 className='text-greenGR text-2xl mb-5'>"Yesql" repository</h1>
+            <h1 className='text-greenGR text-2xl mb-5'>"{selected}" repository</h1>
             <ul className='list-disc list-inside'>
-              <li className='text-white my-4'>
-                Used React to develop an application which mirrors the functionality of Chrome Developer Tools Styles tab but displays source file names and line numbers for all types of CSS styles, enabling faster CSS debugging and development.
-              </li>
-              <li className='text-white my-4'>
-                Integrated DOM and CSS domains of Chrome Developer Protocol to communicate directly with browser’s functionality without abstraction layers provided by higher-level libraries and to fetch CSS property data of the target application.
-              </li>
-              <li className='text-white my-4'>
-                Implemented Redux Toolkit, using Immer and Redux thunks to simplify state management across multiple React components, handle asynchronous HTTP and API requests, ensure immutable state update and efficient data flow.
-              </li>
+              {bulletPointElements}
             </ul>
           </div>
           <Button
             className="my-8 hover:bg-lavenderGR focus:bg-blueGR"
             variant='default'
-            // onClick={}
+            onClick={handleCopyToClipboardClick}
           >Copy To Clipboard</Button>
         </div>
       </main>

--- a/client/pages/DataDisplay.tsx
+++ b/client/pages/DataDisplay.tsx
@@ -1,21 +1,34 @@
 import React from 'react';
+import { Button } from '../components/ui/get-started-button';
 
 const DataDisplay = () => {
   return (
     <div>
-      <header className='p-4 text-sm text-white'>
+      <header className='p-4 text-sm text-white absolute top-0 left-0 z-10'>
         <a href='/repodisplay'>← Back to repositories</a>
       </header>
       
-      <main>
-        <div>
-          <h1 className='text-greenGR'>Yesql</h1>
-          <ul>
-            <li className='text-white'>Bullet One</li>
-            <li className='text-white'>Bullet Two</li>
-            <li className='text-white'>Bullet Three</li>
-          </ul>
-          <button className='bg-greenGR'>Copy To Clipboard</button>
+      <main className='flex items-center justify-center h-screen bg-blackGR'>
+        <div className='bg-darkGrayGR w-3/4 h-4/6 rounded-3xl pt-7 px-10 font-sans flex flex-col items-center justify-between'>
+          <div>
+            <h1 className='text-greenGR text-2xl mb-5'>"Yesql" repository</h1>
+            <ul className='list-disc list-inside'>
+              <li className='text-white my-4'>
+                Used React to develop an application which mirrors the functionality of Chrome Developer Tools Styles tab but displays source file names and line numbers for all types of CSS styles, enabling faster CSS debugging and development.
+              </li>
+              <li className='text-white my-4'>
+                Integrated DOM and CSS domains of Chrome Developer Protocol to communicate directly with browser’s functionality without abstraction layers provided by higher-level libraries and to fetch CSS property data of the target application.
+              </li>
+              <li className='text-white my-4'>
+                Implemented Redux Toolkit, using Immer and Redux thunks to simplify state management across multiple React components, handle asynchronous HTTP and API requests, ensure immutable state update and efficient data flow.
+              </li>
+            </ul>
+          </div>
+          <Button
+            className="my-8 hover:bg-lavenderGR focus:bg-blueGR"
+            variant='default'
+            // onClick={}
+          >Copy To Clipboard</Button>
         </div>
       </main>
     </div>

--- a/client/pages/DataDisplay.tsx
+++ b/client/pages/DataDisplay.tsx
@@ -3,7 +3,21 @@ import React from 'react';
 const DataDisplay = () => {
   return (
     <div>
-
+      <header className='p-4 text-sm text-white'>
+        <a href='/repodisplay'>← Back to repositories</a>
+      </header>
+      
+      <main>
+        <div>
+          <h1 className='text-greenGR'>Yesql</h1>
+          <ul>
+            <li className='text-white'>Bullet One</li>
+            <li className='text-white'>Bullet Two</li>
+            <li className='text-white'>Bullet Three</li>
+          </ul>
+          <button className='bg-greenGR'>Copy To Clipboard</button>
+        </div>
+      </main>
     </div>
   )
 }

--- a/client/pages/DataDisplay.tsx
+++ b/client/pages/DataDisplay.tsx
@@ -1,7 +1,27 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '../components/ui/get-started-button';
+import { useSelectedRepo } from '../components/SelectedRepoProvider';
 
 const DataDisplay = () => {
+  const { selected } = useSelectedRepo();
+  const [bulletPoints, setBulletPoints] = useState([]);
+  console.log('SELECTED:   ', selected);
+
+  useEffect(() => {
+    console.log('Fetching bullet points data...');
+    fetch('/api/github/ghData', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoName: selected })
+    })
+      .then(res => res.json())
+      .then(data => {
+        console.log('DATA DISPLAY COMPONENT: FETCHED DATA:   ', data);
+        setBulletPoints(data);
+      })
+      .catch(err => console.error(`Error fetching bullet points for repo ${selected}. Error: ${err}`))
+  }, []);
+
   return (
     <div>
       <header className='p-4 text-sm text-white absolute top-0 left-0 z-10'>

--- a/client/pages/RepoDisplay.tsx
+++ b/client/pages/RepoDisplay.tsx
@@ -5,15 +5,18 @@ import { SelectedRepoProvider, useSelectedRepo } from '../components/SelectedRep
 import { Button } from '../components/ui/get-started-button';
 import { NavigationMenu } from '../components/ui/NavBar';
 // import arrow from '../assets/icons/arrow.png';
-
+import { useNavigate } from 'react-router-dom';
 
 const RepoDisplay: React.FC = () => {
   const { selected } = useSelectedRepo();
   console.log(selected, 'selected inside repodisplay')
 
+  const navigate = useNavigate();
+
   const handleClickSelect = () => {
     if (selected.length > 0) {
-      console.log('sending repos to backend')
+      console.log('sending repos to backend');
+      navigate('/bulletpoints');
     }
   }
 


### PR DESCRIPTION
Changes made:
1. <DataDisplay /> component has been added, which renders resume bullet points to be received from backend for the selected repository. Meanwhile, it is using hard-coded values. It is styled using tailwind, whenever possible utilizing values used in other components for consistency of UI style.
2. Added a new route for React Router for <DataDisplay/>, enabling navigating to the bullet points screen when "Generate Bullet Points" button has been clicked.