### PR TITLE
code: production backend config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "type": "module",
   "node": ">=18",
   "scripts": {
-    "start": "webpack serve --config webpack.config.js --mode development",
-    "build": "webpack --config webpack.config.js --mode production",
-    "dev": "concurrently --kill-others-on-fail \"npm run serve\" \"nodemon server/server.js\"",
+    "start": "webpack serve --config webpack.config.mjs --hot --open --mode development",
+    "build": "webpack --config webpack.config.mjs --mode production",
+    "dev": "concurrently --kill-others-on-fail \"npm run start\" \"nodemon server/server.js\"",
     "lint": "eslint . && stylelint 'client/**/*.scss'",
     "lint:fix": "eslint . --fix && stylelint 'client/**/*.scss' --fix",
-    "serve": "webpack serve --open --hot --mode development"
+    "prod": "npm run build && npm run serve",
+    "serve": "NODE_ENV=production node server/server.js "
   },
   "repository": {
     "type": "git",

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,8 @@ import express from 'express';
 import session from 'express-session';
 import { config } from 'dotenv';
 import cookieParser from 'cookie-parser';
+import { fileURLToPath } from 'url';
+import path, { dirname } from 'path';
 
 import { authRouter } from './routes/authRouter.js';
 import { githubRouter } from './routes/githubRouter.js';
@@ -13,18 +15,19 @@ const ghClientId = process.env.GH_CLIENT_ID;
 const ghClientSecret = process.env.GH_CLIENT_SECRET;
 const secretKey = process.env.SECRET_KEY;
 
+const MODE = process.env.NODE_ENV || 'development';
+console.log('server.js: environment: ', MODE);
+
 const app = express();
 const PORT = 3000;
 
 app.use(express.json());
 app.use(cookieParser());
 
-// app.use(session({
-//   secret: sessionSecret, // a secret string used to encrypt the session cookie
-//   resave: false, // if true, store session data in server memory.
-//   saveUninitialized: false, // if true, save a session to the store even if it is not modified
-//   cookie: { secure: false } // if true, cookies will only be transmitted over https. Use when deploying to production
-// }));
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+MODE === 'production' ? app.use(express.static(path.join(__dirname, '../dist'))) : null;
 
 app.use('/api/auth/', authRouter);
 
@@ -32,9 +35,7 @@ app.use('/api/github/', githubRouter);
 
 app.use('/api/openai/', openaiRouter);
 
-app.get('/', (req, res) => {
-  res.send('Home page');
-});
+MODE === 'production' ? app.get('/*', (req, res) => {res.sendFile(path.join(__dirname, '../dist', 'index.html'));}) : null;
 
 // global error handler
 app.use((err, req, res, next) => {


### PR DESCRIPTION
production build is now running correctly (for me). in package.json, updated a few scripts and added one (npm run prod, which both builds and serves the production bundle). in server, added a check for node_env, now serves static files from dist in that event. and modified the prior catch-all route to point to it too. react router + webpack's historyApiFallback take care of the same in dev mode